### PR TITLE
Add KeepAlive setting. More accurate forward latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,26 +31,32 @@ The tool supports multiple concurrent clients, configurable message size, etc:
 Usage of ./mqtt-bm-latency:
   -broker string
         MQTT broker endpoint as scheme://host:port (default "tcp://localhost:1883")
-  -clients int
-        Number of clients pair to start (default 10)
-  -count int
-        Number of messages to send per pubclient (default 100)
-  -format string
-        Output format: text|json (default "text")
-  -password string
-        MQTT password (empty if auth disabled)
-  -pubqos int
-        QoS for published messages (default 1)
-  -quiet
-        Suppress logs while running
-  -size int
-        Size of the messages payload (bytes) (default 100)
-  -subqos int
-        QoS for subscribed messages (default 1)
   -topic string
         MQTT topic for outgoing messages (default "/test")
   -username string
         MQTT username (empty if auth disabled)
+  -password string
+        MQTT password (empty if auth disabled)
+  -pubqos int
+        QoS for published messages (default 1)
+  -subqos int
+        QoS for subscribed messages (default 1)
+  -size int
+        Size of the messages payload (bytes) (default 100)
+  -clients int
+        Number of clients pair to start (default 10)
+  -count int
+        Number of messages to send per pubclient (default 100)
+  -keepalive int
+        Keep alive period in seconds (default 60)
+  -format string
+        Benchmark results output format: text|json (default "text")
+  -quiet
+        Suppress logs while running
+
+
+
+
 ```
 
 Two output formats supported: human-readable plain text and JSON.

--- a/main.go
+++ b/main.go
@@ -84,17 +84,18 @@ type JSONResults struct {
 func main() {
 
 	var (
-		broker   = flag.String("broker", "tcp://localhost:1883", "MQTT broker endpoint as scheme://host:port")
-		topic    = flag.String("topic", "/test", "MQTT topic for outgoing messages")
-		username = flag.String("username", "", "MQTT username (empty if auth disabled)")
-		password = flag.String("password", "", "MQTT password (empty if auth disabled)")
+		broker      = flag.String("broker", "tcp://localhost:1883", "MQTT broker endpoint as scheme://host:port")
+		topic       = flag.String("topic", "/test", "MQTT topic for outgoing messages")
+		username    = flag.String("username", "", "MQTT username (empty if auth disabled)")
+		password    = flag.String("password", "", "MQTT password (empty if auth disabled)")
 		pubqos      = flag.Int("pubqos", 1, "QoS for published messages")
 		subqos      = flag.Int("subqos", 1, "QoS for subscribed messages")
-		size     = flag.Int("size", 100, "Size of the messages payload (bytes)")
-		count    = flag.Int("count", 100, "Number of messages to send per pubclient")
-		clients  = flag.Int("clients", 10, "Number of clients pair to start")
-		format   = flag.String("format", "text", "Output format: text|json")
-		quiet    = flag.Bool("quiet", false, "Suppress logs while running")
+		size        = flag.Int("size", 100, "Size of the messages payload (bytes)")
+		count       = flag.Int("count", 100, "Number of messages to send per pubclient")
+		clients     = flag.Int("clients", 10, "Number of clients pair to start")
+                keepalive   = flag.Int("keepalive", 60, "Keep alive period in seconds")
+		format      = flag.String("format", "text", "Output format: text|json")
+		quiet       = flag.Bool("quiet", false, "Suppress logs while running")
 	)
 
 	flag.Parse()
@@ -121,6 +122,7 @@ func main() {
 			BrokerPass: *password,
 			SubTopic:   *topic + "-" + strconv.Itoa(i),
 			SubQoS:     byte(*subqos),
+			KeepAlive:  *keepalive,
 			Quiet:      *quiet,
 		}
 		go sub.run(subResCh, subDone, jobDone)
@@ -156,6 +158,7 @@ func main() {
 			MsgSize:    *size,
 			MsgCount:   *count,
 			PubQoS:     byte(*pubqos),
+                        KeepAlive:  *keepalive,
 			Quiet:      *quiet,
 		}
 		go c.run(pubResCh)

--- a/pubclient.go
+++ b/pubclient.go
@@ -22,6 +22,7 @@ type PubClient struct {
 	MsgSize    int
 	MsgCount   int
 	PubQoS     byte
+        KeepAlive  int
 	Quiet      bool
 }
 
@@ -111,12 +112,15 @@ func (c *PubClient) pubMessages(in, out chan *Message, doneGen, donePub chan boo
 		}
 	}
 
+	ka, _ := time.ParseDuration(strconv.Itoa(c.KeepAlive) + "s")
+
 	opts := mqtt.NewClientOptions().
 		AddBroker(c.BrokerURL).
 		SetClientID(fmt.Sprintf("mqtt-benchmark-%v-%v", time.Now(), c.ID)).
 		SetCleanSession(true).
 		SetAutoReconnect(true).
 		SetOnConnectHandler(onConnected).
+		SetKeepAlive(ka).
 		SetConnectionLostHandler(func(client mqtt.Client, reason error) {
 		log.Printf("PUBLISHER %v lost connection to the broker: %v. Will reconnect...\n", c.ID, reason.Error())
 	})


### PR DESCRIPTION
1. Add the setting of keep alive.
2. Forward latency of each subscriber is in float64 now instead of int.